### PR TITLE
[Feat] 알림 이력 테이블 엔티티 및 VO 작성

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/constants/NotificationResultStatus.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/constants/NotificationResultStatus.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.notification.domain.constants;
+
+public enum NotificationResultStatus {
+  PENDING,
+  SEND,
+  FAILED,
+  GIVE_UP
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/constants/NotificationType.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/constants/NotificationType.java
@@ -1,0 +1,15 @@
+package com.yeoljeong.tripmate.notification.domain.constants;
+
+public enum NotificationType {
+  PLAN_CONFIRMED,
+
+  MATCHING_REQUIRED,
+  MATCHING_MATCHED,
+  MATCHING_SUCCEED,
+  MATCHING_FAILED,
+
+  PAYMENT_SUCCEED,
+  PAYMENT_FAILED,
+
+  COMPANY_APPROVED
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationHistory.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationHistory.java
@@ -39,6 +39,20 @@ public class NotificationHistory extends BaseAuditEntity {
   @Embedded
   private NotificationResult notificationResult;
 
+  private NotificationHistory(NotificationEndPoint endPoint, NotificationSource source,
+      NotificationMessage message, NotificationPayload payload, NotificationResult result) {
+    this.notificationEndPointSnapShot = endPoint;
+    this.notificationSource = source;
+    this.notificationMessage = message;
+    this.notificationPayload = payload;
+    this.notificationResult = result;
+  }
+
+  public static NotificationHistory create(NotificationEndPoint endPoint, NotificationSource source,
+      NotificationMessage message, NotificationPayload payload, NotificationResult result) {
+    return new NotificationHistory(endPoint, source, message, payload, result);
+  }
+
   public void updateResult(NotificationResult notificationResult) {
     this.notificationResult = notificationResult;
   }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationHistory.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationHistory.java
@@ -1,0 +1,57 @@
+package com.yeoljeong.tripmate.notification.domain.entity;
+
+import com.yeoljeong.tripmate.domain.BaseAuditEntity;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(name = "p_notification_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationHistory extends BaseAuditEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @UuidGenerator
+  private UUID id;
+
+  @Embedded
+  private NotificationEndPoint notificationEndPointSnapShot;
+
+  @Embedded
+  private NotificationSource notificationSource;
+
+  @Embedded
+  private NotificationMessage notificationMessage;
+
+  @Embedded
+  private NotificationPayload notificationPayload;
+
+  @Embedded
+  private NotificationResult notificationResult;
+
+  public void updateResult(NotificationResult notificationResult) {
+    this.notificationResult = notificationResult;
+  }
+
+  protected boolean isFailed() {
+    return notificationResult.isFailed();
+  }
+
+  protected NotificationType getNotificationType() {
+    return this.notificationSource.getType();
+  }
+
+  protected ChannelType getNotificationChannelType() {
+    return this.notificationEndPointSnapShot.getChannelType();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationMessage.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationMessage.java
@@ -22,7 +22,7 @@ public class NotificationMessage {
     this.redirectUrl = redirectUrl;
   }
 
-  public static NotificationMessageBuilder create(String title, String body, String redirectUrl) {
+  public static NotificationMessageBuilder create() {
     return NotificationMessage.builder();
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationMessage.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationMessage.java
@@ -1,0 +1,28 @@
+package com.yeoljeong.tripmate.notification.domain.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class NotificationMessage {
+
+  private String title;
+  private String body;
+  private String redirectUrl;
+
+  private NotificationMessage(String title, String body, String redirectUrl) {
+    this.title = title;
+    this.body = body;
+    this.redirectUrl = redirectUrl;
+  }
+
+  public static NotificationMessageBuilder create(String title, String body, String redirectUrl) {
+    return NotificationMessage.builder();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationPayload.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationPayload.java
@@ -1,0 +1,34 @@
+package com.yeoljeong.tripmate.notification.domain.entity;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.notification.domain.exception.NotificationHistoryErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationPayload {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Column(nullable = false)
+  private String payload;
+
+  public NotificationPayload(String payload) {
+    validate(payload);
+  }
+
+  private void validate(String payload) {
+    try {
+      objectMapper.readTree(payload);
+    } catch (JacksonException e) {
+      throw new BusinessException(NotificationHistoryErrorCode.INVALID_JSON_FORMAT);
+    }
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationPayload.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationPayload.java
@@ -22,6 +22,7 @@ public class NotificationPayload {
 
   public NotificationPayload(String payload) {
     validate(payload);
+    this.payload = payload;
   }
 
   private void validate(String payload) {

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationPayload.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationPayload.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationPayload {
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Column(nullable = false)
   private String payload;
@@ -26,7 +26,7 @@ public class NotificationPayload {
 
   private void validate(String payload) {
     try {
-      objectMapper.readTree(payload);
+      OBJECT_MAPPER.readTree(payload);
     } catch (JacksonException e) {
       throw new BusinessException(NotificationHistoryErrorCode.INVALID_JSON_FORMAT);
     }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationResult.java
@@ -1,0 +1,52 @@
+package com.yeoljeong.tripmate.notification.domain.entity;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationResultStatus;
+import com.yeoljeong.tripmate.notification.domain.exception.NotificationHistoryErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationResult {
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "notification_result_status", nullable = false)
+  private NotificationResultStatus status;
+  @Column(nullable = false)
+  private int retryCount;
+  private String failReason;
+
+  private NotificationResult(NotificationResultStatus status, int retryCount, String failReason) {
+    this.retryCount = retryCount;
+    this.status = status;
+    this.failReason = failReason;
+  }
+
+  public static NotificationResult pending() {
+    return new NotificationResult(NotificationResultStatus.PENDING, 0, null);
+  }
+
+  public static NotificationResult sent() {
+    return new NotificationResult(NotificationResultStatus.SEND, 0, null);
+  }
+
+  public NotificationResult markFailure(int MAX_RETRY_COUNT, String failReason) {
+    int next = this.retryCount + 1;
+    if (failReason == null) {
+      throw new BusinessException(NotificationHistoryErrorCode.FAIL_REASON_REQUIRED);
+    }
+    if (next >= MAX_RETRY_COUNT) {
+      return new NotificationResult(NotificationResultStatus.GIVE_UP, next, failReason);
+    }
+    return new NotificationResult(NotificationResultStatus.FAILED, this.retryCount + 1, failReason);
+  }
+
+  protected boolean isFailed() {
+    return this.status == NotificationResultStatus.FAILED;
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationSource.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/entity/NotificationSource.java
@@ -1,0 +1,37 @@
+package com.yeoljeong.tripmate.notification.domain.entity;
+
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSource {
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "notification_type", nullable = false)
+  private NotificationType type;
+
+  @Column()
+  private UUID refId;
+
+  @Column(nullable = false)
+  private String eventHash;
+
+  private NotificationSource(NotificationType type, UUID refId, String eventHash) {
+    this.type = type;
+    this.refId = refId;
+    this.eventHash = eventHash;
+  }
+
+  public static NotificationSource create(NotificationType type, UUID refId, String eventHash) {
+    return new NotificationSource(type, refId, eventHash);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/exception/NotificationHistoryErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/exception/NotificationHistoryErrorCode.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.notification.domain.exception;
+
+import com.yeoljeong.tripmate.exception.constants.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum NotificationHistoryErrorCode implements ErrorCode {
+  FAIL_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "발송 실패일 경우 실패 이유가 필수입니다."),
+  INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "payload는 json 타입이여야 합니다."),
+
+  ;
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public int getCode() {
+    return this.status.value();
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 알림 발송 이력 관리 도메인 설계 및 관련 상수/엔티티 구현
알림 서비스의 핵심 엔티티인 NotificationHistory를 구현하고, 알림 유형(NotificationType), 상태(NotificationResultStatus), 메시지 구성 요소들을 도메인 주도 설계(DDD)의 VO 형태로 정의했습니다. 이를 통해 알림의 생성부터 결과(성공/실패/재시도 포기)까지의 생명주기를 데이터베이스에서 추적할 수 있는 기반을 마련했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
 - **도메인 엔티티 및 상수 정의**
     - **`NotificationHistory` 엔티티 생성**: 알림 도메인의 Root 엔티티로, `BaseAuditEntity`를 상속받아 생성/수정 시간을 추적하며 JPA Embedded 타입을 통해 구성 요소를 분리했습니다.
- **알림 상태 및 유형 정의**: 
  - `NotificationResultStatus`: PENDING, SEND, FAILED, GIVE_UP(재시도 초과) 상태 추가.
  - `NotificationType`: 여행 계획 확정, 매칭 관련, 결제 관련 등 프로젝트 비즈니스 로직에 필요한 알림 타입 정의.
- **VO(Value Object) 구현**:
  - `NotificationMessage`: 알림의 제목, 본문, 리다이렉트 URL 관리.
  - `NotificationPayload`: JSON 형식 검증 로직이 포함된 알림 데이터 관리. (`ObjectMapper`를 통한 Validation)
  - `NotificationResult`: 재시도 횟수(retryCount) 및 실패 사유를 포함한 상태 관리 로직 구현.
  - `NotificationSource`: 알림의 발생 근거가 되는 이벤트 타입과 참조 ID(`refId`), 중복 방지를 위한 `eventHash` 포함.
- **예외 처리**: `NotificationHistoryErrorCode`를 정의하여 JSON 형식 오류나 실패 사유 누락 시의 비즈니스 예외 처리 추가.


### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- [알림 정책 관리](https://www.notion.so/teamsparta/34f2dc3ef51480b8b19de44baa017833), [알림 엔티티 설계](https://www.notion.so/teamsparta/Notification-Domain-Entity-VO-34e2dc3ef51480ffa325ec2f22924a3d)
- `NotificationResult` 클래스 내에 `markFailure` 메서드가 포함되어 있습니다. 호출 시 `MAX_RETRY_COUNT`를 인자로 받아, 최대 재시도 횟수 도달 시 상태를 자동으로 `GIVE_UP`으로 변경하도록 설계되어 있습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 알림 이력 추적 기능 추가 — 각 알림의 전송 기록을 저장하고 상태를 관리합니다.
  * 다양한 알림 유형 지원 (계획, 매칭 단계별, 결제 결과, 회사 승인 등).
  * 전송 상태 관리 추가 (대기, 전송 완료, 실패, 재시도 중단).
  * 알림 메시지 구성(타이틀·본문·리다이렉트) 도입.
  * 페이로드 JSON 검증 및 유효성 검사 추가.
  * 재시도 로직과 실패 처리 개선.
  * 관련 오류 코드 추가(잘못된 JSON 형식, 실패 사유 필수).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->