### PR TITLE
[Feat] 토큰 갱신 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/NotificationServiceApplication.java
+++ b/src/main/java/com/yeoljeong/tripmate/NotificationServiceApplication.java
@@ -5,10 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @EnableDiscoveryClient
-@SpringBootApplication(scanBasePackages = {
-    "com.yeoljeong.tripmate.notification",
-    "com.yeoljeong.tripmate.common"
-})
+@SpringBootApplication
 public class NotificationServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationTokenCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationTokenCommand.java
@@ -1,13 +1,15 @@
 package com.yeoljeong.tripmate.notification.application.dto.command;
 
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record NotificationTokenCommand(
     UUID userId,
-    String channelType,
-    String deviceType,
+    ChannelType channelType,
+    DeviceType deviceType,
     String deviceId,
     String tokenValue
 ) {

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationTokenCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationTokenCommand.java
@@ -1,0 +1,15 @@
+package com.yeoljeong.tripmate.notification.application.dto.command;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record NotificationTokenCommand(
+    UUID userId,
+    String channelType,
+    String deviceType,
+    String deviceId,
+    String tokenValue
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationTokenResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationTokenResult.java
@@ -1,0 +1,26 @@
+package com.yeoljeong.tripmate.notification.application.dto.result;
+
+import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record NotificationTokenResult(
+    String channelType,
+    String deviceType,
+    String deviceId,
+    String tokenValue,
+    LocalDateTime updateAt
+) {
+
+  public static NotificationTokenResult from(NotificationToken token) {
+    return NotificationTokenResult
+        .builder()
+        .channelType(String.valueOf(token.getNotificationEndPoint().getChannelType()))
+        .deviceType(String.valueOf(token.getNotificationEndPoint().getDeviceType()))
+        .deviceId(token.getNotificationEndPoint().getDeviceId())
+        .tokenValue(token.getNotificationEndPoint().getTokenValue())
+        .updateAt(token.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationTokenResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationTokenResult.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.notification.application.dto.result;
 
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.Builder;
 
 @Builder
@@ -16,8 +17,10 @@ public record NotificationTokenResult(
   public static NotificationTokenResult from(NotificationToken token) {
     return NotificationTokenResult
         .builder()
-        .channelType(String.valueOf(token.getNotificationEndPoint().getChannelType()))
-        .deviceType(String.valueOf(token.getNotificationEndPoint().getDeviceType()))
+        .channelType(token.getNotificationEndPoint().getChannelType().name())
+        .deviceType(
+            Optional.of(token.getNotificationEndPoint().getDeviceType().name()).orElse(null)
+        )
         .deviceId(token.getNotificationEndPoint().getDeviceId())
         .tokenValue(token.getNotificationEndPoint().getTokenValue())
         .updateAt(token.getUpdatedAt())

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationTokenResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationTokenResult.java
@@ -19,7 +19,9 @@ public record NotificationTokenResult(
         .builder()
         .channelType(token.getNotificationEndPoint().getChannelType().name())
         .deviceType(
-            Optional.of(token.getNotificationEndPoint().getDeviceType().name()).orElse(null)
+            Optional.ofNullable(token.getNotificationEndPoint().getDeviceType())
+                .map(Enum::name)
+                .orElse(null)
         )
         .deviceId(token.getNotificationEndPoint().getDeviceId())
         .tokenValue(token.getNotificationEndPoint().getTokenValue())

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationCommandService.java
@@ -1,0 +1,10 @@
+package com.yeoljeong.tripmate.notification.application.service.command;
+
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationTokenCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
+
+public interface NotificationCommandService {
+
+  NotificationTokenResult registerTokenData(NotificationTokenCommand command);
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
@@ -3,12 +3,11 @@ package com.yeoljeong.tripmate.notification.application.service.command.impl;
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationTokenCommand;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
 import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
-import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
-import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationEndPoint;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
 import com.yeoljeong.tripmate.notification.domain.model.TokenStatus;
 import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
+import jakarta.transaction.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,22 +19,24 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
   private final NotificationRepository notificationRepository;
 
   @Override
+  @Transactional
   public NotificationTokenResult registerTokenData(NotificationTokenCommand command) {
 
-    ChannelType channelType = ChannelType.valueOf(command.channelType());
-    DeviceType deviceType = DeviceType.valueOf(command.deviceType());
     String deviceId = command.deviceId();
     String tokenValue = command.tokenValue();
 
     processDuplicateToken(command.userId(), tokenValue);
 
-    NotificationEndPoint newEndPoint = NotificationEndPoint.create(channelType, deviceType,
-        deviceId, tokenValue);
+    NotificationEndPoint newEndPoint =
+        NotificationEndPoint.create(command.channelType(),
+            command.deviceType(),
+            deviceId, tokenValue);
 
     NotificationToken myTokenData = notificationRepository
         .findByUserIdAndChannelTypeAndDeviceIdAndDeviceType(
-            command.userId(), channelType, deviceId, deviceType)
+            command.userId(), command.channelType(), deviceId, command.deviceType())
         .map(tokenData -> {
+          tokenData.updateTokenEndpoint(newEndPoint);
           tokenData.updateTokenStatus(TokenStatus.inactiveInitial());
           return tokenData;
         })

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
@@ -1,0 +1,63 @@
+package com.yeoljeong.tripmate.notification.application.service.command.impl;
+
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationTokenCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
+import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationEndPoint;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
+import com.yeoljeong.tripmate.notification.domain.model.TokenStatus;
+import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationCommandServiceImpl implements NotificationCommandService {
+
+  private final NotificationRepository notificationRepository;
+
+  @Override
+  public NotificationTokenResult registerTokenData(NotificationTokenCommand command) {
+
+    ChannelType channelType = ChannelType.valueOf(command.channelType());
+    DeviceType deviceType = DeviceType.valueOf(command.deviceType());
+    String deviceId = command.deviceId();
+    String tokenValue = command.tokenValue();
+
+    processDuplicateToken(command.userId(), tokenValue);
+
+    NotificationEndPoint newEndPoint = NotificationEndPoint.create(channelType, deviceType,
+        deviceId, tokenValue);
+
+    NotificationToken myTokenData = notificationRepository
+        .findByUserIdAndChannelTypeAndDeviceIdAndDeviceType(
+            command.userId(), channelType, deviceId, deviceType)
+        .map(tokenData -> {
+          tokenData.updateTokenStatus(TokenStatus.inactiveInitial());
+          return tokenData;
+        })
+        .orElseGet(() -> NotificationToken.create(
+            command.userId(),
+            newEndPoint,
+            TokenStatus.activeInitial()
+        ));
+
+    return NotificationTokenResult.from(notificationRepository.save(myTokenData));
+  }
+
+  private void processDuplicateToken(
+      UUID userId,
+      String tokenValue) {
+    notificationRepository
+        .findByTokenValue(tokenValue)
+        .ifPresent(existingToken -> {
+          if (!existingToken.getUserId().equals(userId)) {
+            existingToken.updateTokenStatus(TokenStatus.inactiveInitial());
+            notificationRepository.save(existingToken);
+          }
+        });
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationToken.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationToken.java
@@ -8,12 +8,26 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "p_notification_token")
+@Table(
+    name = "p_notification_token",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_notification_endpoint",
+            columnNames = {"user_id", "channel_type", "device_type", "device_id"}
+        ),
+        @UniqueConstraint(
+            name = "uk_token_value",
+            columnNames = {"token_value"}
+        )
+    })
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationToken extends BaseAuditEntity {
 
@@ -48,5 +62,9 @@ public class NotificationToken extends BaseAuditEntity {
 
   public boolean isTokenUsable() {
     return tokenStatus.isUsable();
+  }
+
+  public void updateTokenEndpoint(NotificationEndPoint endPoint) {
+    this.notificationEndPoint = endPoint;
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,18 @@
+package com.yeoljeong.tripmate.notification.domain.repository;
+
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface NotificationRepository {
+
+  Optional<NotificationToken> findByTokenValue(String notificationEndPoint_tokenValue);
+
+  Optional<NotificationToken> findByUserIdAndChannelTypeAndDeviceIdAndDeviceType(
+      UUID userId, ChannelType notificationEndPoint_channelType,
+      String notificationEndPoint_deviceId, DeviceType notificationEndPoint_deviceType);
+
+  NotificationToken save(NotificationToken myTokenData);
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationTokenJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationTokenJpaRepository.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa;
+
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationTokenJpaRepository extends JpaRepository<NotificationToken, UUID> {
+
+  Optional<NotificationToken> findByNotificationEndPoint_TokenValue
+      (String notificationEndPoint_tokenValue);
+
+  Optional<NotificationToken> findByUserIdAndNotificationEndPoint_ChannelTypeAndNotificationEndPoint_DeviceIdAndNotificationEndPoint_DeviceType
+      (
+          UUID userId,
+          ChannelType notificationEndPoint_channelType,
+          String notificationEndPoint_deviceId,
+          DeviceType notificationEndPoint_deviceType
+      );
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.yeoljeong.tripmate.notification.infrastructure.persistence.repositoryImpl;
+
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
+import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
+import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationTokenJpaRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepository {
+
+  private final NotificationTokenJpaRepository tokenJpaRepository;
+
+  @Override
+  public Optional<NotificationToken> findByTokenValue(String tokenValue) {
+    return tokenJpaRepository.findByNotificationEndPoint_TokenValue(tokenValue);
+  }
+
+  @Override
+  public Optional<NotificationToken> findByUserIdAndChannelTypeAndDeviceIdAndDeviceType
+      (UUID userId, ChannelType channelType, String deviceId, DeviceType deviceType) {
+    return tokenJpaRepository
+        .findByUserIdAndNotificationEndPoint_ChannelTypeAndNotificationEndPoint_DeviceIdAndNotificationEndPoint_DeviceType(
+            userId, channelType, deviceId, deviceType);
+  }
+
+  @Override
+  public NotificationToken save(NotificationToken tokenData) {
+    return tokenJpaRepository.save(tokenData);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
@@ -1,0 +1,36 @@
+package com.yeoljeong.tripmate.notification.presentation.controller.external;
+
+import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
+import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationTokenRequest;
+import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationTokenResponse;
+import com.yeoljeong.tripmate.response.ApiResponse;
+import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationCommandService notificationCommandService;
+
+  @PostMapping("/tokens")
+  public ApiResponse<NotificationTokenResponse> registerTokenData(
+      @RequestHeader(name = "X-Request-ID") UUID userId,
+      @Validated @RequestBody NotificationTokenRequest request
+  ) {
+    return ApiResponse.success(
+        CommonSuccessCode.OK,
+        NotificationTokenResponse.from(
+            notificationCommandService.registerTokenData(request.toCommand(userId))
+        )
+    );
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationTokenRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationTokenRequest.java
@@ -1,0 +1,33 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.request;
+
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationTokenCommand;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record NotificationTokenRequest(
+    @NotNull
+    @Pattern(regexp = "EMAIL|PUSH")
+    String channelType,
+
+    @NotNull
+    @Pattern(regexp = "IOS|WEB|ANDROID")
+    String deviceType,
+
+    String deviceId,
+
+    @NotNull
+    String tokenValue) {
+
+  public NotificationTokenCommand toCommand(UUID userId) {
+    return NotificationTokenCommand.builder()
+        .channelType(channelType)
+        .tokenValue(tokenValue)
+        .deviceId(deviceId)
+        .deviceType(deviceType)
+        .userId(userId)
+        .build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationTokenRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationTokenRequest.java
@@ -1,20 +1,19 @@
 package com.yeoljeong.tripmate.notification.presentation.dto.request;
 
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationTokenCommand;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record NotificationTokenRequest(
     @NotNull
-    @Pattern(regexp = "EMAIL|PUSH")
-    String channelType,
+    ChannelType channelType,
 
     @NotNull
-    @Pattern(regexp = "IOS|WEB|ANDROID")
-    String deviceType,
+    DeviceType deviceType,
 
     String deviceId,
 

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationTokenResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationTokenResponse.java
@@ -1,0 +1,26 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.response;
+
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record NotificationTokenResponse(
+    String channelType,
+    String deviceType,
+    String deviceId,
+    String tokenValue,
+    LocalDateTime updateAt
+) {
+
+  public static NotificationTokenResponse from(NotificationTokenResult result) {
+    return NotificationTokenResponse
+        .builder()
+        .channelType(result.channelType())
+        .deviceType(result.deviceType())
+        .deviceId(result.deviceId())
+        .tokenValue(result.tokenValue())
+        .updateAt(result.updateAt())
+        .build();
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 알림 서비스(Notification Service)에서 사용자별/기기별 알림 토큰을 관리하는 핵심 로직을 구현했습니다.
- 단순히 토큰을 저장하는 것을 넘어, **동일한 토큰이 다른 사용자에게 등록될 경우 기존 관계를 끊어주는(Deactivate) 로직**을 포함하여 알림 전송의 정확성을 높였습니다.
- MSA 환경에서의 정합성을 위해 데이터베이스 계층의 유니크 제약 조건을 강화했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- **도메인 로직 및 엔티티 수정**
    - `NotificationToken`: `user_id` + `channel_type` + `device_type` + `device_id` 조합의 복합 유니크 제약 조건 추가 및 토큰 값(`token_value`) 유니크 제약 조건 추가.
    - `TokenStatus`: 토큰의 활성/비활성 상태를 관리하는 로직 추가.
- **서비스 구현 (`NotificationCommandServiceImpl`)**
    - `registerTokenData`: 토큰 등록 시 기존 사용자/기기 조합이 있으면 상태를 업데이트하고, 없으면 새로 생성합니다.
    - `processDuplicateToken`: 새로운 토큰이 등록될 때, 동일한 토큰 값이 다른 사용자 ID로 이미 존재한다면 기존 토큰을 `inactive`로 변경하여 중복 수신을 방지합니다.
- **인프라 계층 구현**
    - `NotificationRepositoryImpl` & `NotificationTokenJpaRepository`: 도메인 엔티티의 필드 구조(Value Object 포함)에 맞춘 쿼리 메서드 구현.
- **API 레이어**
    - `NotificationController`: POST `/notifications/tokens` 구현 (X-Request-ID 헤더에서 userId 추출).
    - `NotificationTokenRequest`: `EMAIL|PUSH` 및 `IOS|WEB|ANDROID` 값에 대한 Bean Validation 적용.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- **데이터베이스 인덱스**: 이번에 추가된 유니크 인덱스(`uk_notification_endpoint`, `uk_token_value`)로 인해 기존에 중복된 데이터가 로컬 DB에 있다면 DDL 적용 시 에러가 발생할 수 있습니다. 테스트 전 데이터를 정리해 주세요.
- **헤더 필수값**: API 호출 시 `X-Request-ID` 헤더에 UUID 형식의 사용자 ID를 반드시 포함해야 합니다. (Gateway에서 전달 예정)
- **도메인 주도 설계**: `NotificationEndPoint`라는 Value Object를 통해 토큰 정보를 캡슐화하고 있으므로, 필드 접근 시 해당 객체를 거쳐야 함을 유의해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 토큰 등록 API 추가 (POST /notifications/tokens)
  * 채널·기기 정보와 토큰을 제출해 등록 및 갱신 가능
  * 동일 토큰 감지 시 기존 토큰을 비활성화하고 신규 토큰으로 처리
  * 토큰 정보에 대한 고유성 제약을 강화하고 요청 입력 검증 적용
  * 등록 결과에 토큰 갱신 시각(updateAt)을 포함하여 반환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->