### PR TITLE
[Feat] 알림 발송 로직 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/notification/application/provider/NotificationSender.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/provider/NotificationSender.java
@@ -1,0 +1,12 @@
+package com.yeoljeong.tripmate.notification.application.provider;
+
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSendCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+
+public interface NotificationSender {
+
+  NotificationSendResult send(NotificationSendCommand command);
+
+  boolean supports(ChannelType type);
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationSendService.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationSendService.java
@@ -1,0 +1,25 @@
+package com.yeoljeong.tripmate.notification.application.service.command;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.exception.constants.CommonErrorCode;
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSendCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
+import com.yeoljeong.tripmate.notification.application.provider.NotificationSender;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationSendService {
+
+  private final List<NotificationSender> senders;
+
+  public NotificationSendResult send(NotificationSendCommand command) {
+    NotificationSender sender = senders.stream()
+        .filter(senders -> senders.supports(command.channelType()))
+        .findFirst()
+        .orElseThrow(() -> new BusinessException(CommonErrorCode.METHOD_NOT_ALLOWED));
+    return sender.send(command);
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/exception/FirebaseErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/exception/FirebaseErrorCode.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum FirebaseErrorCode implements ErrorCode {
   FIREBASE_INIT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase SDK 초기화에 실패하였습니다."),
-
-  ;
+  EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "만료되었거나 유효하지 않은 푸시 토큰입니다."),
+  INVALID_NOTIFICATION_FORMAT(HttpStatus.BAD_REQUEST, "알림 메시지 형식이 잘못되었습니다."),
+  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "알림 발송 한도를 초과했습니다. 잠시 후 다시 시도해주세요."),
+  FCM_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 서버 일시적 오류로 알림 전송에 실패했습니다."),
+  INTERNAL_NOTIFICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알림 시스템 내부 오류가 발생했습니다.");
   private final HttpStatus status;
   private final String message;
 

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/mail/MailNotificationAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/mail/MailNotificationAdapter.java
@@ -1,0 +1,53 @@
+package com.yeoljeong.tripmate.notification.infrastructure.external.mail;
+
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSendCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationIndividualResult;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
+import com.yeoljeong.tripmate.notification.application.provider.NotificationSender;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class MailNotificationAdapter implements NotificationSender {
+
+  private final JavaMailSender javaMailSender;
+
+  private MimeMessage createMessage(NotificationSendCommand command, String mail)
+      throws MessagingException {
+    MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+    MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+    mimeMessageHelper.setSubject(command.body());
+    mimeMessageHelper.setTo(mail);
+    mimeMessageHelper.setText(command.body());
+    return mimeMessage;
+  }
+
+  @Override
+  public NotificationSendResult send(NotificationSendCommand command) {
+    List<NotificationIndividualResult> results = new ArrayList<>();
+    for (int i = 0; i < command.tokens().toArray().length; i++) {
+      try {
+        javaMailSender.send(createMessage(command, command.tokens().get(i)));
+        results.add(NotificationIndividualResult.success());
+      } catch (MessagingException e) {
+        results.add(NotificationIndividualResult.fail(e.getMessage()));
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean supports(ChannelType type) {
+    return type == ChannelType.EMAIL;
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/mail/MailNotificationAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/mail/MailNotificationAdapter.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class MailNotificationAdapter implements NotificationSender {
       throws MessagingException {
     MimeMessage mimeMessage = javaMailSender.createMimeMessage();
     MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-    mimeMessageHelper.setSubject(command.body());
+    mimeMessageHelper.setSubject(command.title());
     mimeMessageHelper.setTo(mail);
     mimeMessageHelper.setText(command.body());
     return mimeMessage;
@@ -39,11 +40,11 @@ public class MailNotificationAdapter implements NotificationSender {
       try {
         javaMailSender.send(createMessage(command, command.tokens().get(i)));
         results.add(NotificationIndividualResult.success());
-      } catch (MessagingException e) {
+      } catch (MailException | MessagingException e) {
         results.add(NotificationIndividualResult.fail(e.getMessage()));
       }
     }
-    return null;
+    return NotificationSendResult.from(results);
   }
 
   @Override

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/push/FcmNotificationAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/push/FcmNotificationAdapter.java
@@ -41,21 +41,23 @@ public class FcmNotificationAdapter implements NotificationSender {
   @Override
   public NotificationSendResult send(NotificationSendCommand command) {
     MulticastMessage message = createMessage(command);
-    try {
-      BatchResponse response = sendPushMessageForMulticast(message);
-      List<NotificationIndividualResult> details =
-          response.getResponses().stream()
-              .map(res ->
-                  res.isSuccessful()
-                      ? NotificationIndividualResult.success()
-                      : NotificationIndividualResult.fail(res.getException().getMessage())
-              )
-              .toList();
-      return NotificationSendResult.from(details);
-    } catch (FirebaseMessagingException e) {
-      handleFcmException(e);
-      return null;
+    if (command.tokens() != null) {
+      try {
+        BatchResponse response = sendPushMessageForMulticast(message);
+        List<NotificationIndividualResult> details =
+            response.getResponses().stream()
+                .map(res ->
+                    res.isSuccessful()
+                        ? NotificationIndividualResult.success()
+                        : NotificationIndividualResult.fail(res.getException().getMessage())
+                )
+                .toList();
+        return NotificationSendResult.from(details);
+      } catch (FirebaseMessagingException e) {
+        handleFcmException(e);
+      }
     }
+    return null;
   }
 
   @Override

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/push/FcmNotificationAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/push/FcmNotificationAdapter.java
@@ -1,0 +1,77 @@
+package com.yeoljeong.tripmate.notification.infrastructure.external.push;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSendCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationIndividualResult;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
+import com.yeoljeong.tripmate.notification.application.provider.NotificationSender;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.exception.FirebaseErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class FcmNotificationAdapter implements NotificationSender {
+
+  private MulticastMessage createMessage(NotificationSendCommand command) {
+    return MulticastMessage.builder()
+        .addAllTokens(command.tokens())
+        .setNotification(
+            Notification
+                .builder()
+                .setTitle(command.title())
+                .setBody(command.body())
+                .build()
+        ).build();
+  }
+
+  private BatchResponse sendPushMessageForMulticast(MulticastMessage message)
+      throws FirebaseMessagingException {
+    return FirebaseMessaging.getInstance().sendEachForMulticast(message);
+  }
+
+  @Override
+  public NotificationSendResult send(NotificationSendCommand command) {
+    MulticastMessage message = createMessage(command);
+    try {
+      BatchResponse response = sendPushMessageForMulticast(message);
+      List<NotificationIndividualResult> details =
+          response.getResponses().stream()
+              .map(res ->
+                  res.isSuccessful()
+                      ? NotificationIndividualResult.success()
+                      : NotificationIndividualResult.fail(res.getException().getMessage())
+              )
+              .toList();
+      return NotificationSendResult.from(details);
+    } catch (FirebaseMessagingException e) {
+      handleFcmException(e);
+      return null;
+    }
+  }
+
+  @Override
+  public boolean supports(ChannelType type) {
+    return type == ChannelType.PUSH;
+  }
+
+  private void handleFcmException(FirebaseMessagingException e) {
+    MessagingErrorCode fcmCode = e.getMessagingErrorCode();
+    FirebaseErrorCode targetError = switch (fcmCode) {
+      case UNREGISTERED -> FirebaseErrorCode.EXPIRED_TOKEN;
+      case QUOTA_EXCEEDED -> FirebaseErrorCode.RATE_LIMIT_EXCEEDED;
+      case INTERNAL, UNAVAILABLE -> FirebaseErrorCode.FCM_SERVER_ERROR;
+      case INVALID_ARGUMENT -> FirebaseErrorCode.INVALID_NOTIFICATION_FORMAT;
+      default -> FirebaseErrorCode.INTERNAL_NOTIFICATION_ERROR;
+    };
+    throw new BusinessException(targetError);
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 알림 이벤트 발생을 위한 인터페이스 분리, 어댑터 패턴을 사용하였습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- SendService, Sener, MailAdapter, FcmAdapter
-  메일, fcm 발송 시 부분 실패 처리, 인프라 오류시 에러 발생

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일 및 푸시 채널용 발송 플러그인(채널별 전송기) 추가
  * 채널에 따라 발송을 자동 라우팅하는 중앙 전송 서비스 추가

* **버그 수정 / 안정성**
  * 토큰 만료, 잘못된 메시지 형식, 발송 한도 초과 등 상세한 오류 코드 및 사용자 메시지 보강
  * 수신자별 성공/실패 집계 및 지원 발송기 미존재 시 빠른 실패 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->