### PR TITLE
[Feat] 내 알림 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/condition/NotificationHistorySearchCondition.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/condition/NotificationHistorySearchCondition.java
@@ -1,0 +1,20 @@
+package com.yeoljeong.tripmate.notification.application.dto.condition;
+
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationResultStatus;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import java.util.UUID;
+import lombok.Builder;
+import org.springframework.data.domain.Pageable;
+
+@Builder
+public record NotificationHistorySearchCondition(
+    UUID userId,
+    NotificationResultStatus status,
+    ChannelType channelType,
+    NotificationType notificationType,
+    Boolean isRead,
+    Pageable pageable
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationHistoryIndividualResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationHistoryIndividualResult.java
@@ -1,0 +1,24 @@
+package com.yeoljeong.tripmate.notification.application.dto.result;
+
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
+import lombok.Builder;
+
+@Builder
+public record NotificationHistoryIndividualResult(
+    NotificationType notificationType,
+    String title,
+    String content,
+    String redirectUrl,
+    Boolean isRead
+) {
+
+  public static NotificationHistoryIndividualResult from(NotificationHistory history) {
+    return NotificationHistoryIndividualResult.builder()
+        .notificationType(history.getNotificationSource().getType())
+        .title(history.getNotificationMessage().getTitle())
+        .content(history.getNotificationMessage().getBody())
+        .redirectUrl(history.getNotificationMessage().getRedirectUrl())
+        .isRead(history.isRead()).build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/NotificationQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/NotificationQueryService.java
@@ -1,9 +1,15 @@
 package com.yeoljeong.tripmate.notification.application.service.query;
 
+import com.yeoljeong.tripmate.notification.application.dto.condition.NotificationHistorySearchCondition;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface NotificationQueryService {
 
   NotificationSettingResult getSettingData(UUID userId);
+
+  Page<NotificationHistory> getNotificationsByCondition(
+      NotificationHistorySearchCondition searchCondition);
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/NotificationQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/NotificationQueryService.java
@@ -1,8 +1,8 @@
 package com.yeoljeong.tripmate.notification.application.service.query;
 
 import com.yeoljeong.tripmate.notification.application.dto.condition.NotificationHistorySearchCondition;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationHistoryIndividualResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
-import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 
@@ -10,6 +10,6 @@ public interface NotificationQueryService {
 
   NotificationSettingResult getSettingData(UUID userId);
 
-  Page<NotificationHistory> getNotificationsByCondition(
+  Page<NotificationHistoryIndividualResult> getNotificationsByCondition(
       NotificationHistorySearchCondition searchCondition);
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/impl/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/impl/NotificationQueryServiceImpl.java
@@ -1,25 +1,42 @@
 package com.yeoljeong.tripmate.notification.application.service.query.impl;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.notification.application.dto.condition.NotificationHistorySearchCondition;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
 import com.yeoljeong.tripmate.notification.application.service.query.NotificationQueryService;
 import com.yeoljeong.tripmate.notification.domain.exception.NotificationSettingErrorCode;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
-import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationSettingJpaRepository;
+import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationQueryServiceImpl implements NotificationQueryService {
 
-  private final NotificationSettingJpaRepository notificationSettingJpaRepository;
+  private final NotificationRepository notificationRepository;
 
   public NotificationSettingResult getSettingData(UUID userId) {
-    NotificationSetting settingData = notificationSettingJpaRepository.findById(userId)
+    NotificationSetting settingData = notificationRepository.findSettingDataById(userId)
         .orElseThrow(
             () -> new BusinessException(NotificationSettingErrorCode.USER_SETTING_NOT_FOUND));
     return NotificationSettingResult.from(settingData);
+  }
+
+  @Override
+  public Page<NotificationHistory> getNotificationsByCondition(
+      NotificationHistorySearchCondition searchCondition) {
+    return notificationRepository.getNotificationsByCondition
+        (
+            searchCondition.userId(),
+            searchCondition.status(),
+            searchCondition.channelType(),
+            searchCondition.notificationType(),
+            searchCondition.isRead(),
+            searchCondition.pageable()
+        );
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/impl/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/query/impl/NotificationQueryServiceImpl.java
@@ -2,10 +2,10 @@ package com.yeoljeong.tripmate.notification.application.service.query.impl;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.notification.application.dto.condition.NotificationHistorySearchCondition;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationHistoryIndividualResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
 import com.yeoljeong.tripmate.notification.application.service.query.NotificationQueryService;
 import com.yeoljeong.tripmate.notification.domain.exception.NotificationSettingErrorCode;
-import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
 import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
 import java.util.UUID;
@@ -27,7 +27,7 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
   }
 
   @Override
-  public Page<NotificationHistory> getNotificationsByCondition(
+  public Page<NotificationHistoryIndividualResult> getNotificationsByCondition(
       NotificationHistorySearchCondition searchCondition) {
     return notificationRepository.getNotificationsByCondition
         (
@@ -37,6 +37,6 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
             searchCondition.notificationType(),
             searchCondition.isRead(),
             searchCondition.pageable()
-        );
+        ).map(NotificationHistoryIndividualResult::from);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/constants/NotificationType.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/constants/NotificationType.java
@@ -11,5 +11,7 @@ public enum NotificationType {
   PAYMENT_SUCCEED,
   PAYMENT_FAILED,
 
-  COMPANY_APPROVED
+  COMPANY_APPROVED,
+
+  ADMIN_SEND
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
@@ -59,7 +59,7 @@ public class NotificationHistory extends BaseAuditEntity {
     this.notificationResult = notificationResult;
   }
 
-  public void markRead() {
+  public void markAsRead() {
     this.isRead = true;
   }
 

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
@@ -35,7 +35,7 @@ public class NotificationHistory extends BaseAuditEntity {
   @Embedded
   private NotificationResult notificationResult;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false NOT NULL")
   private boolean isRead;
 
   private NotificationHistory(UUID userId, NotificationEndPoint endPoint, NotificationSource source,

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
@@ -1,8 +1,6 @@
 package com.yeoljeong.tripmate.notification.domain.model;
 
 import com.yeoljeong.tripmate.domain.BaseAuditEntity;
-import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
-import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -21,8 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationHistory extends BaseAuditEntity {
 
-  @Column(nullable = false)
-  private final boolean isRead = false;
+
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
@@ -38,6 +35,9 @@ public class NotificationHistory extends BaseAuditEntity {
   @Embedded
   private NotificationResult notificationResult;
 
+  @Column(nullable = false)
+  private boolean isRead;
+
   private NotificationHistory(UUID userId, NotificationEndPoint endPoint, NotificationSource source,
       NotificationMessage message, NotificationPayload payload, NotificationResult result) {
     this.userId = userId;
@@ -46,6 +46,7 @@ public class NotificationHistory extends BaseAuditEntity {
     this.notificationMessage = message;
     this.notificationPayload = payload;
     this.notificationResult = result;
+    this.isRead = false;
   }
 
   public static NotificationHistory create(UUID userId, NotificationEndPoint endPoint,
@@ -58,15 +59,11 @@ public class NotificationHistory extends BaseAuditEntity {
     this.notificationResult = notificationResult;
   }
 
-  protected boolean isFailed() {
+  public void markRead() {
+    this.isRead = true;
+  }
+
+  public boolean isFailed() {
     return notificationResult.isFailed();
-  }
-
-  protected NotificationType getNotificationType() {
-    return this.notificationSource.getType();
-  }
-
-  protected ChannelType getNotificationChannelType() {
-    return this.notificationEndPointSnapShot.getChannelType();
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.notification.domain.model;
 import com.yeoljeong.tripmate.domain.BaseAuditEntity;
 import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
 import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,31 +12,29 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "p_notification_history")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationHistory extends BaseAuditEntity {
 
+  @Column(nullable = false)
+  private final boolean isRead = false;
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
-
   private UUID userId;
-
   @Embedded
   private NotificationEndPoint notificationEndPointSnapShot;
-
   @Embedded
   private NotificationSource notificationSource;
-
   @Embedded
   private NotificationMessage notificationMessage;
-
   @Embedded
   private NotificationPayload notificationPayload;
-
   @Embedded
   private NotificationResult notificationResult;
 

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationResult.java
@@ -8,9 +8,11 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationResult {
 

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/TokenStatus.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/TokenStatus.java
@@ -7,10 +7,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Embeddable
 @RequiredArgsConstructor
+@Getter
 public class TokenStatus {
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
@@ -2,10 +2,15 @@ package com.yeoljeong.tripmate.notification.domain.repository;
 
 import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
 import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationResultStatus;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface NotificationRepository {
 
@@ -20,4 +25,9 @@ public interface NotificationRepository {
   Optional<NotificationSetting> findSettingDataById(UUID userId);
 
   NotificationSetting saveForSettingData(NotificationSetting setting);
+
+  Page<NotificationHistory> getNotificationsByCondition(UUID userId,
+      NotificationResultStatus status,
+      ChannelType channelType, NotificationType notificationType,
+      Boolean isRead, Pageable pageable);
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationHistoryJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationHistoryJpaRepository.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, UUID>,
+public interface NotificationHistoryJpaRepository extends JpaRepository<NotificationHistory, UUID>,
     JpaSpecificationExecutor<NotificationHistory> {
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationHistoryRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa;
+
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, UUID>,
+    JpaSpecificationExecutor<NotificationHistory> {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
@@ -8,7 +8,7 @@ import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
 import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
-import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationHistoryRepository;
+import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationHistoryJpaRepository;
 import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationSettingJpaRepository;
 import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationTokenJpaRepository;
 import jakarta.persistence.criteria.Predicate;
@@ -28,7 +28,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
 
   private final NotificationTokenJpaRepository notificationTokenJpaRepository;
   private final NotificationSettingJpaRepository notificationSettingJpaRepository;
-  private final NotificationHistoryRepository notificationHistoryRepository;
+  private final NotificationHistoryJpaRepository notificationHistoryJpaRepository;
 
   @Override
   public Optional<NotificationToken> findTokenDataByTokenValue(String tokenValue) {
@@ -88,6 +88,6 @@ public class NotificationRepositoryImpl implements NotificationRepository {
       }
       return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
     });
-    return notificationHistoryRepository.findAll(specification, pageable);
+    return notificationHistoryJpaRepository.findAll(specification, pageable);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
@@ -2,14 +2,24 @@ package com.yeoljeong.tripmate.notification.infrastructure.persistence.repositor
 
 import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
 import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationResultStatus;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
 import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
+import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationHistoryRepository;
 import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationSettingJpaRepository;
 import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationTokenJpaRepository;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,6 +28,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
 
   private final NotificationTokenJpaRepository notificationTokenJpaRepository;
   private final NotificationSettingJpaRepository notificationSettingJpaRepository;
+  private final NotificationHistoryRepository notificationHistoryRepository;
 
   @Override
   public Optional<NotificationToken> findTokenDataByTokenValue(String tokenValue) {
@@ -45,5 +56,38 @@ public class NotificationRepositoryImpl implements NotificationRepository {
   @Override
   public NotificationSetting saveForSettingData(NotificationSetting settingData) {
     return notificationSettingJpaRepository.save(settingData);
+  }
+
+  @Override
+  public Page<NotificationHistory> getNotificationsByCondition(
+      UUID userId,
+      NotificationResultStatus status,
+      ChannelType channelType,
+      NotificationType notificationType,
+      Boolean isRead,
+      Pageable pageable
+  ) {
+    Specification<NotificationHistory> specification = ((root, query, criteriaBuilder) -> {
+      List<Predicate> predicates = new ArrayList<>();
+
+      predicates.add(criteriaBuilder.equal(root.get("userId"), userId));
+      if (channelType != null) {
+        predicates.add(
+            criteriaBuilder.equal(root.get("notificationEndPointSnapShot").get("channelType"),
+                channelType));
+      }
+      if (status != null) {
+        predicates.add(criteriaBuilder.equal(root.get("notificationResult").get("status"), status));
+      }
+      if (notificationType != null) {
+        predicates.add(criteriaBuilder.equal(root.get("notificationSource").get("type"),
+            notificationType));
+      }
+      if (isRead != null) {
+        predicates.add(criteriaBuilder.equal(root.get("isRead"), isRead));
+      }
+      return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+    });
+    return notificationHistoryRepository.findAll(specification, pageable);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
@@ -4,6 +4,8 @@ import com.yeoljeong.tripmate.auth.LoginUser;
 import com.yeoljeong.tripmate.auth.UserContext;
 import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
 import com.yeoljeong.tripmate.notification.application.service.query.NotificationQueryService;
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
+import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationHistorySearchByUserRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationSettingRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationTokenRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationSettingResponse;
@@ -12,8 +14,12 @@ import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -65,5 +71,17 @@ public class NotificationController {
         ));
   }
 
-
+  @GetMapping("/me")
+  public ApiResponse<Page<NotificationHistory>> getHistoryData(
+      @LoginUser UserContext userContext,
+      @ModelAttribute NotificationHistorySearchByUserRequest request,
+      @PageableDefault Pageable pageable
+  ) {
+    return ApiResponse.success(
+        CommonSuccessCode.OK,
+        notificationQueryService.getNotificationsByCondition(
+            request.toCondition(UUID.fromString(userContext.userId()), pageable)
+        )
+    );
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
@@ -4,17 +4,16 @@ import com.yeoljeong.tripmate.auth.LoginUser;
 import com.yeoljeong.tripmate.auth.UserContext;
 import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
 import com.yeoljeong.tripmate.notification.application.service.query.NotificationQueryService;
-import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationHistorySearchByUserRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationSettingRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationTokenRequest;
+import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationHistoryResponse;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationSettingResponse;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationTokenResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
@@ -72,16 +71,17 @@ public class NotificationController {
   }
 
   @GetMapping("/me")
-  public ApiResponse<Page<NotificationHistory>> getHistoryData(
+  public ApiResponse<NotificationHistoryResponse> getHistoryData(
       @LoginUser UserContext userContext,
       @ModelAttribute NotificationHistorySearchByUserRequest request,
       @PageableDefault Pageable pageable
   ) {
     return ApiResponse.success(
         CommonSuccessCode.OK,
-        notificationQueryService.getNotificationsByCondition(
-            request.toCondition(UUID.fromString(userContext.userId()), pageable)
-        )
+        NotificationHistoryResponse.from(
+            notificationQueryService.getNotificationsByCondition(
+                request.toCondition(UUID.fromString(userContext.userId()), pageable)
+            ))
     );
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationHistorySearchByUserRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationHistorySearchByUserRequest.java
@@ -1,0 +1,25 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.request;
+
+import com.yeoljeong.tripmate.notification.application.dto.condition.NotificationHistorySearchCondition;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationResultStatus;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+
+public record NotificationHistorySearchByUserRequest(
+    NotificationType notificationType,
+    Boolean isRead
+) {
+
+  public NotificationHistorySearchCondition toCondition(UUID userId, Pageable pageable) {
+    return NotificationHistorySearchCondition.builder()
+        .userId(userId)
+        .status(NotificationResultStatus.SEND)
+        .channelType(ChannelType.PUSH)
+        .notificationType(notificationType)
+        .isRead(isRead)
+        .pageable(pageable)
+        .build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationHistoryIndividualResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationHistoryIndividualResponse.java
@@ -1,0 +1,25 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.response;
+
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationHistoryIndividualResult;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import lombok.Builder;
+
+@Builder
+public record NotificationHistoryIndividualResponse(
+    NotificationType notificationType,
+    String title,
+    String content,
+    String redirectUrl,
+    Boolean isRead
+) {
+
+  public static NotificationHistoryIndividualResponse from(
+      NotificationHistoryIndividualResult result) {
+    return NotificationHistoryIndividualResponse.builder()
+        .notificationType(result.notificationType())
+        .title(result.title())
+        .content(result.content())
+        .redirectUrl(result.redirectUrl())
+        .isRead(result.isRead()).build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationHistoryResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationHistoryResponse.java
@@ -1,0 +1,18 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.response;
+
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationHistoryIndividualResult;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+public record NotificationHistoryResponse(
+    Page<NotificationHistoryIndividualResponse> histories
+) {
+
+  public static NotificationHistoryResponse from(
+      Page<NotificationHistoryIndividualResult> results) {
+    return NotificationHistoryResponse.builder()
+        .histories(results.map(NotificationHistoryIndividualResponse::from))
+        .build();
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- History 조회 API 를 구현하였습니다. 
- JPA SpecificationExcutor를 이용해 동적 쿼리를 구현하였습니다.
- 사용자의 입장에선 isRead와  notificationType,page만 쿼리로 받고 다른 필드는 고정하였습니다. 추후 관리자용 조회를 위해 채널 타입, status를 추가하였습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- NotificationRepostiory, - > JPAExcuator 상속 받도록 수정
- 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- dto에 Condition 패키지에 searchCondition 작성하였는데 적절한지 알려주세요
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 알림 검색·필터링 기능 추가(유저, 전송상태, 채널, 유형, 읽음 여부, 페이징)
  * 사용자별 페이징 알림 이력 조회 API 추가(GET /notifications/me)
  * 알림 영구적 읽음 상태 저장 및 읽음 처리(mark as read) 지원
  * 새로운 알림 유형 추가(회사 승인, 관리자 발송)
  * 응답 포맷 개선: 개별 항목 및 페이징 응답 DTO 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->