### PR TITLE
[Feat] 관리자용 알림 발송 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/NotificationServiceApplication.java
+++ b/src/main/java/com/yeoljeong/tripmate/NotificationServiceApplication.java
@@ -2,9 +2,11 @@ package com.yeoljeong.tripmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @EnableDiscoveryClient
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class NotificationServiceApplication {
 

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationAdminSendRequestCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationAdminSendRequestCommand.java
@@ -1,0 +1,16 @@
+package com.yeoljeong.tripmate.notification.application.dto.command;
+
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record NotificationAdminSendRequestCommand(
+    List<UUID> userList,
+    ChannelType channelType,
+    String title,
+    String body
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationSendCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/command/NotificationSendCommand.java
@@ -1,0 +1,15 @@
+package com.yeoljeong.tripmate.notification.application.dto.command;
+
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record NotificationSendCommand(
+    List<String> tokens,
+    ChannelType channelType,
+    String title,
+    String body
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationIndividualResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationIndividualResult.java
@@ -9,13 +9,15 @@ public record NotificationIndividualResult(
     String errorMessage
 ) {
 
-  public static NotificationIndividualResult success() {
+  public static NotificationIndividualResult success(int index) {
     return NotificationIndividualResult.builder()
+        .index(index)
         .isSuccess(true).build();
   }
 
-  public static NotificationIndividualResult fail(String errorMessage) {
+  public static NotificationIndividualResult fail(int index, String errorMessage) {
     return NotificationIndividualResult.builder()
+        .index(index)
         .isSuccess(false)
         .errorMessage(errorMessage)
         .build();

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationIndividualResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationIndividualResult.java
@@ -1,0 +1,23 @@
+package com.yeoljeong.tripmate.notification.application.dto.result;
+
+import lombok.Builder;
+
+@Builder
+public record NotificationIndividualResult(
+    int index,
+    boolean isSuccess,
+    String errorMessage
+) {
+
+  public static NotificationIndividualResult success() {
+    return NotificationIndividualResult.builder()
+        .isSuccess(true).build();
+  }
+
+  public static NotificationIndividualResult fail(String errorMessage) {
+    return NotificationIndividualResult.builder()
+        .isSuccess(false)
+        .errorMessage(errorMessage)
+        .build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationSendResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationSendResult.java
@@ -1,0 +1,13 @@
+package com.yeoljeong.tripmate.notification.application.dto.result;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record NotificationSendResult(List<NotificationIndividualResult> results) {
+
+  public static NotificationSendResult from(List<NotificationIndividualResult> results) {
+    return NotificationSendResult.builder().results(results).build();
+  }
+}
+

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationCommandService.java
@@ -1,7 +1,9 @@
 package com.yeoljeong.tripmate.notification.application.service.command;
 
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationAdminSendRequestCommand;
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSettingCommand;
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationTokenCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
 
@@ -10,4 +12,8 @@ public interface NotificationCommandService {
   NotificationTokenResult registerTokenData(NotificationTokenCommand command);
 
   NotificationSettingResult updateSettingData(NotificationSettingCommand command);
+
+  NotificationSendResult sendNotificationByAdmin(
+      NotificationAdminSendRequestCommand requestCommand
+  );
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
@@ -1,11 +1,16 @@
 package com.yeoljeong.tripmate.notification.application.service.command.impl;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationAdminSendRequestCommand;
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSendCommand;
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSettingCommand;
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationTokenCommand;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
 import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
+import com.yeoljeong.tripmate.notification.application.service.command.NotificationSendService;
+import com.yeoljeong.tripmate.notification.domain.constants.TokenActiveStatus;
 import com.yeoljeong.tripmate.notification.domain.exception.NotificationSettingErrorCode;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationEndPoint;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
@@ -13,6 +18,8 @@ import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
 import com.yeoljeong.tripmate.notification.domain.model.TokenStatus;
 import com.yeoljeong.tripmate.notification.domain.repository.NotificationRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +29,7 @@ import org.springframework.stereotype.Service;
 public class NotificationCommandServiceImpl implements NotificationCommandService {
 
   private final NotificationRepository notificationRepository;
+  private final NotificationSendService notificationSendService;
 
   @Override
   @Transactional
@@ -75,5 +83,31 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
             notificationRepository.saveForTokenData(existingToken);
           }
         });
+  }
+
+  @Override
+  public NotificationSendResult sendNotificationByAdmin(
+      NotificationAdminSendRequestCommand requestCommand
+  ) {
+    List<NotificationToken> tokenEntities = notificationRepository
+        .findSendableTokens(
+            requestCommand.userList(),
+            requestCommand.channelType(),
+            TokenActiveStatus.ACTIVE
+        );
+
+    List<String> tokens = tokenEntities.stream()
+        .map(NotificationToken::getTokenValue)
+        .filter(Objects::nonNull)
+        .toList();
+
+    return notificationSendService.send(
+        NotificationSendCommand.builder()
+            .tokens(tokens)
+            .title(requestCommand.title())
+            .body(requestCommand.body())
+            .channelType(requestCommand.channelType())
+            .build()
+    );
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationToken.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationToken.java
@@ -56,6 +56,10 @@ public class NotificationToken extends BaseAuditEntity {
     return new NotificationToken(userId, notificationEndPoint, tokenStatus);
   }
 
+  public String getTokenValue() {
+    return notificationEndPoint.getTokenValue();
+  }
+
   public void updateTokenStatus(TokenStatus tokenStatus) {
     this.tokenStatus = tokenStatus;
   }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
@@ -4,13 +4,16 @@ import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
 import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
 import com.yeoljeong.tripmate.notification.domain.constants.NotificationResultStatus;
 import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import com.yeoljeong.tripmate.notification.domain.constants.TokenActiveStatus;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository {
 
@@ -30,4 +33,10 @@ public interface NotificationRepository {
       NotificationResultStatus status,
       ChannelType channelType, NotificationType notificationType,
       Boolean isRead, Pageable pageable);
+  
+  List<NotificationToken> findSendableTokens(
+      @Param("userIds") List<UUID> userIds,
+      @Param("channelType") ChannelType channelType,
+      @Param("activeStatus") TokenActiveStatus activeStatus
+  );
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/mail/MailNotificationAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/mail/MailNotificationAdapter.java
@@ -39,9 +39,9 @@ public class MailNotificationAdapter implements NotificationSender {
     for (int i = 0; i < command.tokens().toArray().length; i++) {
       try {
         javaMailSender.send(createMessage(command, command.tokens().get(i)));
-        results.add(NotificationIndividualResult.success());
+        results.add(NotificationIndividualResult.success(i));
       } catch (MailException | MessagingException e) {
-        results.add(NotificationIndividualResult.fail(e.getMessage()));
+        results.add(NotificationIndividualResult.fail(i, e.getMessage()));
       }
     }
     return NotificationSendResult.from(results);

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/push/FcmNotificationAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/external/push/FcmNotificationAdapter.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationSendCommand;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationIndividualResult;
@@ -14,6 +15,7 @@ import com.yeoljeong.tripmate.notification.application.provider.NotificationSend
 import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
 import com.yeoljeong.tripmate.notification.domain.exception.FirebaseErrorCode;
 import java.util.List;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -44,14 +46,17 @@ public class FcmNotificationAdapter implements NotificationSender {
     if (command.tokens() != null) {
       try {
         BatchResponse response = sendPushMessageForMulticast(message);
-        List<NotificationIndividualResult> details =
-            response.getResponses().stream()
-                .map(res ->
-                    res.isSuccessful()
-                        ? NotificationIndividualResult.success()
-                        : NotificationIndividualResult.fail(res.getException().getMessage())
-                )
-                .toList();
+        List<SendResponse> responses = response.getResponses();
+
+        List<NotificationIndividualResult> details = IntStream.range(0, responses.size())
+            .mapToObj(index -> {
+              SendResponse res = responses.get(index);
+              return res.isSuccessful()
+                  ? NotificationIndividualResult.success(index)
+                  : NotificationIndividualResult.fail(index, res.getException().getMessage());
+            })
+            .toList();
+        
         return NotificationSendResult.from(details);
       } catch (FirebaseMessagingException e) {
         handleFcmException(e);

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationTokenJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationTokenJpaRepository.java
@@ -2,10 +2,14 @@ package com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa;
 
 import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
 import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
+import com.yeoljeong.tripmate.notification.domain.constants.TokenActiveStatus;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationTokenJpaRepository extends JpaRepository<NotificationToken, UUID> {
 
@@ -19,4 +23,17 @@ public interface NotificationTokenJpaRepository extends JpaRepository<Notificati
           String notificationEndPoint_deviceId,
           DeviceType notificationEndPoint_deviceType
       );
+
+  @Query("""
+          select nt
+          from NotificationToken nt
+          where nt.userId in :userIds
+            and nt.notificationEndPoint.channelType = :channelType
+            and nt.tokenStatus.activeStatus = :activeStatus
+      """)
+  List<NotificationToken> findSendableTokens(
+      @Param("userIds") List<UUID> userIds,
+      @Param("channelType") ChannelType channelType,
+      @Param("activeStatus") TokenActiveStatus activeStatus
+  );
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
 import com.yeoljeong.tripmate.notification.domain.constants.DeviceType;
 import com.yeoljeong.tripmate.notification.domain.constants.NotificationResultStatus;
 import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import com.yeoljeong.tripmate.notification.domain.constants.TokenActiveStatus;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
@@ -89,5 +90,11 @@ public class NotificationRepositoryImpl implements NotificationRepository {
       return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
     });
     return notificationHistoryJpaRepository.findAll(specification, pageable);
+  }
+
+  @Override
+  public List<NotificationToken> findSendableTokens(List<UUID> userIds, ChannelType channelType,
+      TokenActiveStatus activeStatus) {
+    return notificationTokenJpaRepository.findSendableTokens(userIds, channelType, activeStatus);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
@@ -95,6 +95,9 @@ public class NotificationRepositoryImpl implements NotificationRepository {
   @Override
   public List<NotificationToken> findSendableTokens(List<UUID> userIds, ChannelType channelType,
       TokenActiveStatus activeStatus) {
+    if (userIds == null || userIds.isEmpty()) {
+      return List.of();
+    }
     return notificationTokenJpaRepository.findSendableTokens(userIds, channelType, activeStatus);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
@@ -1,13 +1,15 @@
 package com.yeoljeong.tripmate.notification.presentation.controller.external;
 
-import com.yeoljeong.tripmate.auth.LoginUser;
-import com.yeoljeong.tripmate.auth.UserContext;
+import com.yeoljeong.tripmate.auth.annotation.LoginUser;
+import com.yeoljeong.tripmate.auth.context.UserContext;
 import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
 import com.yeoljeong.tripmate.notification.application.service.query.NotificationQueryService;
+import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationAdminSendRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationHistorySearchByUserRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationSettingRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationTokenRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationHistoryResponse;
+import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationSendResponse;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationSettingResponse;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationTokenResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
@@ -82,6 +84,20 @@ public class NotificationController {
             notificationQueryService.getNotificationsByCondition(
                 request.toCondition(UUID.fromString(userContext.userId()), pageable)
             ))
+    );
+  }
+
+  @PostMapping("/admin/send")
+  public ApiResponse<NotificationSendResponse> adminSendNotification(
+      @RequestBody @Validated NotificationAdminSendRequest notificationSendRequest
+  ) {
+    return ApiResponse.success(
+        CommonSuccessCode.OK,
+        NotificationSendResponse.from(
+            notificationCommandService.sendNotificationByAdmin(
+                notificationSendRequest.toCommand()
+            )
+        )
     );
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationAdminSendRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationAdminSendRequest.java
@@ -2,13 +2,21 @@ package com.yeoljeong.tripmate.notification.presentation.dto.request;
 
 import com.yeoljeong.tripmate.notification.application.dto.command.NotificationAdminSendRequestCommand;
 import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
+import org.hibernate.validator.constraints.Length;
 
 public record NotificationAdminSendRequest(
+    @NotNull
     List<UUID> userList,
+    @NotNull
     ChannelType channelType,
+    @NotNull
+    @Length(max = 20)
     String title,
+    @Length(max = 255)
+    @NotNull
     String body
 ) {
 

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationAdminSendRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/request/NotificationAdminSendRequest.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.request;
+
+import com.yeoljeong.tripmate.notification.application.dto.command.NotificationAdminSendRequestCommand;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import java.util.List;
+import java.util.UUID;
+
+public record NotificationAdminSendRequest(
+    List<UUID> userList,
+    ChannelType channelType,
+    String title,
+    String body
+) {
+
+  public NotificationAdminSendRequestCommand toCommand() {
+    return NotificationAdminSendRequestCommand.builder()
+        .userList(userList)
+        .channelType(channelType)
+        .title(title)
+        .body(body).build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationSendIndividualResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationSendIndividualResponse.java
@@ -1,0 +1,19 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.response;
+
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationIndividualResult;
+import lombok.Builder;
+
+@Builder
+public record NotificationSendIndividualResponse(
+    int index,
+    boolean isSuccess,
+    String errorMessage
+) {
+
+  public static NotificationSendIndividualResponse from(NotificationIndividualResult result) {
+    return NotificationSendIndividualResponse.builder()
+        .index(result.index())
+        .isSuccess(result.isSuccess())
+        .errorMessage(result.errorMessage()).build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationSendResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationSendResponse.java
@@ -1,0 +1,18 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.response;
+
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record NotificationSendResponse(
+    List<NotificationSendIndividualResponse> responses
+) {
+
+  public static NotificationSendResponse from(NotificationSendResult result) {
+    return NotificationSendResponse.builder()
+        .responses(
+            result.results().stream().map(NotificationSendIndividualResponse::from).toList())
+        .build();
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,3 +10,6 @@ spring:
       - eureka
       - firebase
       - mail
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: TRACE


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 관리자용 알림 발송 트리거 API 구현

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
-
- 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자가 사용자 목록과 채널·제목·본문을 지정해 일괄 알림 전송 가능
  * 전송 결과가 각 대상별 인덱스, 성공/실패 여부 및 오류 메시지를 포함한 상세 응답으로 반환
  * 외부 관리자 전송 API 추가: POST /notifications/admin/send

* **Chores**
  * 설정 및 로깅 구성 업데이트 (Hibernate 바인딩 로그 TRACE)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->