### PR TITLE
[Refactor] 알림 기록과 outbox 분리

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationEventProcessService.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationEventProcessService.java
@@ -7,12 +7,10 @@ import com.yeoljeong.tripmate.notification.application.dto.result.TemplateMessag
 import com.yeoljeong.tripmate.notification.application.provider.NotificationContentProvider;
 import com.yeoljeong.tripmate.notification.domain.constants.TokenActiveStatus;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
-import com.yeoljeong.tripmate.notification.domain.model.NotificationResult;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
 import com.yeoljeong.tripmate.notification.infrastructure.dto.NotificationSendMessage;
 import com.yeoljeong.tripmate.notification.infrastructure.persistence.jpa.NotificationTokenJpaRepository;
 import java.util.List;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -66,15 +64,5 @@ public class NotificationEventProcessService {
             .channelType(processCommand.channelType())
             .build()
     );
-
-    IntStream.range(0, resultList.results().size())
-        .mapToObj(index -> {
-          if (resultList.results().get(index).isSuccess()) {
-            histories.get(index).updateResult(NotificationResult.sent());
-          } else {
-            histories.get(index).updateResult(NotificationResult.sent());
-          }
-          return null;
-        });
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
@@ -16,7 +16,6 @@ import com.yeoljeong.tripmate.notification.domain.model.NotificationEndPoint;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationMessage;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationPayload;
-import com.yeoljeong.tripmate.notification.domain.model.NotificationResult;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSetting;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationSource;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationToken;
@@ -135,8 +134,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                             command.eventHash()),
                         NotificationMessage.create().title(command.title()).body(command.body())
                             .redirectUrl(command.redirectUrl()).build(),
-                        new NotificationPayload(command.payload()),
-                        NotificationResult.pending()
+                        new NotificationPayload(command.payload())
                     )).toList();
     return notificationRepository.saveAllForHistoryData(histories);
   }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/model/NotificationHistory.java
@@ -30,37 +30,26 @@ public class NotificationHistory extends BaseAuditEntity {
   private NotificationMessage notificationMessage;
   @Embedded
   private NotificationPayload notificationPayload;
-  @Embedded
-  private NotificationResult notificationResult;
 
-  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false NOT NULL")
+  @Column(nullable = false)
   private boolean isRead;
 
   private NotificationHistory(UUID userId, NotificationSource source,
-      NotificationMessage message, NotificationPayload payload, NotificationResult result) {
+      NotificationMessage message, NotificationPayload payload) {
     this.userId = userId;
     this.notificationSource = source;
     this.notificationMessage = message;
     this.notificationPayload = payload;
-    this.notificationResult = result;
     this.isRead = false;
   }
 
   public static NotificationHistory create(UUID userId,
       NotificationSource source,
-      NotificationMessage message, NotificationPayload payload, NotificationResult result) {
-    return new NotificationHistory(userId, source, message, payload, result);
-  }
-
-  public void updateResult(NotificationResult notificationResult) {
-    this.notificationResult = notificationResult;
+      NotificationMessage message, NotificationPayload payload) {
+    return new NotificationHistory(userId, source, message, payload);
   }
 
   public void markAsRead() {
     this.isRead = true;
-  }
-
-  public boolean isFailed() {
-    return notificationResult.isFailed();
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/NotificationSendOutbox.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/NotificationSendOutbox.java
@@ -32,6 +32,8 @@ public class NotificationSendOutbox extends Outbox {
   @Column(nullable = false)
   private UUID tokenId;
 
+  private String failReason;
+
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private NotificationType notificationType;
@@ -41,13 +43,20 @@ public class NotificationSendOutbox extends Outbox {
   private ChannelType channelType;
 
   public static NotificationSendOutbox create
-      (String topic, UUID historyId, NotificationType notificationType, UUID tokenId,
+      (String topic, UUID historyId, NotificationType notificationType, ChannelType channelType,
+          UUID tokenId,
           String payload) {
     NotificationSendOutbox outbox = new NotificationSendOutbox();
     init(outbox, topic, payload);
     outbox.historyId = historyId;
     outbox.tokenId = tokenId;
+    outbox.channelType = channelType;
     outbox.notificationType = notificationType;
     return outbox;
+  }
+
+  public void fail(String failReason) {
+    super.fail();
+    this.failReason = failReason;
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/NotificationSendOutbox.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/NotificationSendOutbox.java
@@ -1,0 +1,53 @@
+package com.yeoljeong.tripmate.notification.infrastructure.persistence;
+
+import com.yeoljeong.tripmate.domain.Outbox;
+import com.yeoljeong.tripmate.notification.domain.constants.ChannelType;
+import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_notification_send_outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSendOutbox extends Outbox {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false)
+  private UUID historyId;
+
+  @Column(nullable = false)
+  private UUID tokenId;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private NotificationType notificationType;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private ChannelType channelType;
+
+  public static NotificationSendOutbox create
+      (String topic, UUID historyId, NotificationType notificationType, UUID tokenId,
+          String payload) {
+    NotificationSendOutbox outbox = new NotificationSendOutbox();
+    init(outbox, topic, payload);
+    outbox.historyId = historyId;
+    outbox.tokenId = tokenId;
+    outbox.notificationType = notificationType;
+    return outbox;
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/NotificationSendOutboxJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/NotificationSendOutboxJpaRepository.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.notification.infrastructure.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationSendOutboxJpaRepository extends
+    JpaRepository<NotificationSendOutbox, UUID> {
+
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 알림 기록 테이블에서 발송 상태를 저장하고 있었는데 outbox 테이블로 분리하였습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
-
- 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 알림 시스템의 내부 처리 구조를 개선하여 안정성을 강화했습니다.
  * 알림 이력 저장 모델을 단순화하여 성능을 최적화했습니다.

* **개선 사항**
  * 알림 발송 신뢰성 향상을 위해 아웃박스 패턴을 도입했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/notification-service/pull/46)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->