### PR TITLE
[Feat] Notification 단일 읽기 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationUpdateReadStatusResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationUpdateReadStatusResult.java
@@ -1,0 +1,21 @@
+package com.yeoljeong.tripmate.notification.application.dto.result;
+
+import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record NotificationUpdateReadStatusResult(
+    UUID notification_history_id,
+    boolean isRead,
+    LocalDateTime updateAt
+) {
+
+  public static NotificationUpdateReadStatusResult from(NotificationHistory history) {
+    return NotificationUpdateReadStatusResult.builder()
+        .notification_history_id(history.getId())
+        .isRead(history.isRead())
+        .updateAt(history.getUpdatedAt()).build();
+  }
+}

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/NotificationCommandService.java
@@ -7,8 +7,10 @@ import com.yeoljeong.tripmate.notification.application.dto.command.NotificationT
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationUpdateReadStatusResult;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
 import java.util.List;
+import java.util.UUID;
 
 public interface NotificationCommandService {
 
@@ -21,4 +23,6 @@ public interface NotificationCommandService {
   );
 
   List<NotificationHistory> createHistories(NotificationHistoryCreateCommand command);
+
+  NotificationUpdateReadStatusResult updateReadStatus(UUID uuid, UUID notificationHistoryId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
@@ -9,9 +9,11 @@ import com.yeoljeong.tripmate.notification.application.dto.command.NotificationT
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSendResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationSettingResult;
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationTokenResult;
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationUpdateReadStatusResult;
 import com.yeoljeong.tripmate.notification.application.service.command.NotificationCommandService;
 import com.yeoljeong.tripmate.notification.application.service.command.NotificationSendService;
 import com.yeoljeong.tripmate.notification.domain.constants.TokenActiveStatus;
+import com.yeoljeong.tripmate.notification.domain.exception.NotificationHistoryErrorCode;
 import com.yeoljeong.tripmate.notification.domain.exception.NotificationSettingErrorCode;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationEndPoint;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
@@ -135,5 +137,18 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                         new NotificationPayload(command.payload())
                     )).toList();
     return notificationRepository.saveAllForHistoryData(histories);
+  }
+
+  @Override
+  public NotificationUpdateReadStatusResult updateReadStatus(UUID userId,
+      UUID notificationHistoryId) {
+    NotificationHistory history = notificationRepository.findHistoryDataById(notificationHistoryId)
+        .orElseThrow(() -> new BusinessException(NotificationHistoryErrorCode.HISTORY_NOT_FOUND));
+    if (!history.getUserId().equals(userId)) {
+      throw new BusinessException(NotificationHistoryErrorCode.HISTORY_NOT_ACCESSIBLE);
+    }
+    history.markAsRead();
+    return NotificationUpdateReadStatusResult.from(
+        notificationRepository.saveForHistoryData(history));
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
@@ -139,6 +139,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
     return notificationRepository.saveAllForHistoryData(histories);
   }
 
+  @Transactional
   @Override
   public NotificationUpdateReadStatusResult updateReadStatus(UUID userId,
       UUID notificationHistoryId) {
@@ -148,7 +149,6 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
       throw new BusinessException(NotificationHistoryErrorCode.HISTORY_NOT_ACCESSIBLE);
     }
     history.markAsRead();
-    return NotificationUpdateReadStatusResult.from(
-        notificationRepository.saveForHistoryData(history));
+    return NotificationUpdateReadStatusResult.from(history);
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/exception/NotificationHistoryErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/exception/NotificationHistoryErrorCode.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum NotificationHistoryErrorCode implements ErrorCode {
   FAIL_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "발송 실패일 경우 실패 이유가 필수입니다."),
   INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "payload는 json 타입이여야 합니다."),
+  HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다."),
+  HISTORY_NOT_ACCESSIBLE(HttpStatus.FORBIDDEN, "사용자의 알림이 아닙니다."),
 
   ;
   private final HttpStatus status;

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
@@ -39,4 +39,8 @@ public interface NotificationRepository {
   );
 
   List<NotificationHistory> saveAllForHistoryData(List<NotificationHistory> histories);
+
+  Optional<NotificationHistory> findHistoryDataById(UUID notificationHistoryId);
+
+  NotificationHistory saveForHistoryData(NotificationHistory history);
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
@@ -100,4 +100,14 @@ public class NotificationRepositoryImpl implements NotificationRepository {
   public List<NotificationHistory> saveAllForHistoryData(List<NotificationHistory> histories) {
     return notificationHistoryJpaRepository.saveAll(histories);
   }
+
+  @Override
+  public Optional<NotificationHistory> findHistoryDataById(UUID notificationHistoryId) {
+    return notificationHistoryJpaRepository.findById(notificationHistoryId);
+  }
+
+  @Override
+  public NotificationHistory saveForHistoryData(NotificationHistory history) {
+    return notificationHistoryJpaRepository.save(history);
+  }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/controller/external/NotificationController.java
@@ -9,11 +9,13 @@ import com.yeoljeong.tripmate.notification.presentation.dto.request.Notification
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationSettingRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.request.NotificationTokenRequest;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationHistoryResponse;
+import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationReadUpdateStatusResponse;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationSendResponse;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationSettingResponse;
 import com.yeoljeong.tripmate.notification.presentation.dto.response.NotificationTokenResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -21,6 +23,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -94,6 +97,21 @@ public class NotificationController {
         NotificationSendResponse.from(
             notificationCommandService.sendNotificationByAdmin(
                 notificationSendRequest.toCommand()
+            )
+        )
+    );
+  }
+
+  @PatchMapping("/{notification_history_id}/read")
+  public ApiResponse<NotificationReadUpdateStatusResponse> updateReadStatus(
+      @LoginUser UserContext userContext,
+      @PathVariable UUID notification_history_id
+  ) {
+    return ApiResponse.success(
+        CommonSuccessCode.OK,
+        NotificationReadUpdateStatusResponse.from(
+            notificationCommandService.updateReadStatus(
+                userContext.userId(), notification_history_id
             )
         )
     );

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationReadUpdateStatusResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationReadUpdateStatusResponse.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.notification.presentation.dto.response;
+
+import com.yeoljeong.tripmate.notification.application.dto.result.NotificationUpdateReadStatusResult;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record NotificationReadUpdateStatusResponse(
+    UUID notification_history_id,
+    boolean isRead,
+    LocalDateTime updateAt
+) {
+
+  public static NotificationReadUpdateStatusResponse from(
+      NotificationUpdateReadStatusResult result) {
+    return NotificationReadUpdateStatusResponse.builder()
+        .notification_history_id(result.notification_history_id())
+        .isRead(result.isRead())
+        .updateAt(result.updateAt()).build();
+  }
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
-  알림 단일 읽기를 구현하였습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
-
- 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 알림을 읽음으로 표시할 수 있는 기능이 추가되었습니다. 사용자는 이제 개별 알림의 읽음 상태를 업데이트할 수 있으며, 알림 이력에 대한 접근 제어가 강화되어 권한 있는 사용자만 해당 알림을 수정할 수 있습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/notification-service/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->