### PR TITLE
[Fix] notificationHistory id 반영

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationHistoryIndividualResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/dto/result/NotificationHistoryIndividualResult.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.notification.application.dto.result;
 
 import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
 import com.yeoljeong.tripmate.notification.domain.model.NotificationHistory;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
@@ -10,7 +11,8 @@ public record NotificationHistoryIndividualResult(
     String title,
     String content,
     String redirectUrl,
-    Boolean isRead
+    Boolean isRead,
+    UUID historyId
 ) {
 
   public static NotificationHistoryIndividualResult from(NotificationHistory history) {
@@ -19,6 +21,7 @@ public record NotificationHistoryIndividualResult(
         .title(history.getNotificationMessage().getTitle())
         .content(history.getNotificationMessage().getBody())
         .redirectUrl(history.getNotificationMessage().getRedirectUrl())
+        .historyId(history.getId())
         .isRead(history.isRead()).build();
   }
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationTokenJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/jpa/NotificationTokenJpaRepository.java
@@ -56,4 +56,5 @@ public interface NotificationTokenJpaRepository extends JpaRepository<Notificati
             )
       """)
   boolean isSendableToken(UUID tokenId);
+  
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationHistoryIndividualResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/presentation/dto/response/NotificationHistoryIndividualResponse.java
@@ -2,11 +2,13 @@ package com.yeoljeong.tripmate.notification.presentation.dto.response;
 
 import com.yeoljeong.tripmate.notification.application.dto.result.NotificationHistoryIndividualResult;
 import com.yeoljeong.tripmate.notification.domain.constants.NotificationType;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record NotificationHistoryIndividualResponse(
     NotificationType notificationType,
+    UUID id,
     String title,
     String content,
     String redirectUrl,
@@ -17,6 +19,7 @@ public record NotificationHistoryIndividualResponse(
       NotificationHistoryIndividualResult result) {
     return NotificationHistoryIndividualResponse.builder()
         .notificationType(result.notificationType())
+        .id(result.historyId())
         .title(result.title())
         .content(result.content())
         .redirectUrl(result.redirectUrl())


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- Notification History 조회 시 id 필드를 response에 추가하지 않음으로서 읽음 처리를 할 수 없게 되는 오류 발생
- response에 id 필드 추가
### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
-
- 
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **내부 개선**
  * 알림 이력 추적을 위한 식별자 처리 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/notification-service/pull/77)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->