### PR TITLE
[Fix] 토큰 중복 에러 처리

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/application/service/command/impl/NotificationCommandServiceImpl.java
@@ -88,8 +88,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         .findTokenDataByTokenValue(tokenValue)
         .ifPresent(existingToken -> {
           if (!existingToken.getUserId().equals(userId)) {
-            existingToken.updateTokenStatus(TokenStatus.inactiveInitial());
-            notificationRepository.saveForTokenData(existingToken);
+            notificationRepository.deleteTokenByTokenId(existingToken.getId());
           }
         });
   }

--- a/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/domain/repository/NotificationRepository.java
@@ -55,4 +55,6 @@ public interface NotificationRepository {
 
   void deleteHistoriesByScheduler(ChannelType channelType,
       LocalDateTime cutoff);
+
+  void deleteTokenByTokenId(UUID tokenId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/notification/infrastructure/persistence/repositoryImpl/NotificationRepositoryImpl.java
@@ -140,4 +140,9 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     notificationHistoryJpaRepository.deleteAllByNotificationSource_ChannelTypeAndCreatedAtBefore(
         channelType, cutoff);
   }
+
+  @Override
+  public void deleteTokenByTokenId(UUID tokenId) {
+    notificationTokenJpaRepository.deleteById(tokenId);
+  }
 }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 토큰 갱신 시 중복 처리에서 중복 토큰 비활성화 후 해당 유저의 토큰으로 등록하는 로직이었는데 비활성화 상태만 유지한채 기존 유저의 토큰을 제거하지 않아 DB 유니크 제약으로 실패하였습니다.
- 토큰 유니크 제약 조건을 해제 후 로직 그대로 수행하는 것과 토큰을 nullable 하게 두고 토큰 중복 시 기존 토큰 정보를 삭제하는 것 중에 후자를 선택하였습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 토큰 중복 시 기존 토큰 비활성화 및 토큰 정보 삭제
- 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 기기별 알림 토큰 관리가 개선되어, 여러 기기에서의 알림 수신 안정성이 향상되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/notification-service/pull/89)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->